### PR TITLE
PVS CWE warnings fix

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -48,11 +48,11 @@ int ZEXPORT compress2(dest, destLen, source, sourceLen, level)
 
     do {
         if (stream.avail_out == 0) {
-            stream.avail_out = left > (uLong)max ? max : (uInt)left;
+            stream.avail_out = left > (uLong)max ? max : (uInt)left; //-V547
             left -= stream.avail_out;
         }
         if (stream.avail_in == 0) {
-            stream.avail_in = sourceLen > (uLong)max ? max : (uInt)sourceLen;
+            stream.avail_in = sourceLen > (uLong)max ? max : (uInt)sourceLen; //-V547
             sourceLen -= stream.avail_in;
         }
         err = deflate(&stream, sourceLen ? Z_NO_FLUSH : Z_FINISH);

--- a/contrib/minizip/ioapi.c
+++ b/contrib/minizip/ioapi.c
@@ -76,7 +76,6 @@ void fill_zlib_filefunc64_32_def_from_filefunc32(zlib_filefunc64_32_def* p_filef
     p_filefunc64_32->zfile_func64.ztell64_file = NULL;
     p_filefunc64_32->zfile_func64.zseek64_file = NULL;
     p_filefunc64_32->zfile_func64.zclose_file = p_filefunc32->zclose_file;
-    p_filefunc64_32->zfile_func64.zerror_file = p_filefunc32->zerror_file;
     p_filefunc64_32->zfile_func64.opaque = p_filefunc32->opaque;
     p_filefunc64_32->zseek32_file = p_filefunc32->zseek_file;
     p_filefunc64_32->ztell32_file = p_filefunc32->ztell_file;

--- a/contrib/minizip/iowin32.c
+++ b/contrib/minizip/iowin32.c
@@ -278,7 +278,6 @@ long ZCALLBACK win32_tell_file_func (voidpf opaque,voidpf stream)
         {
             DWORD dwErr = GetLastError();
             ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
-            ret = -1;
         }
         else
             ret=(long)pos.LowPart;
@@ -302,7 +301,6 @@ ZPOS64_T ZCALLBACK win32_tell64_file_func (voidpf opaque, voidpf stream)
         {
             DWORD dwErr = GetLastError();
             ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
-            ret = (ZPOS64_T)-1;
         }
         else
             ret=pos.QuadPart;
@@ -341,7 +339,6 @@ long ZCALLBACK win32_seek_file_func (voidpf opaque,voidpf stream,uLong offset,in
         {
             DWORD dwErr = GetLastError();
             ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
-            ret = -1;
         }
         else
             ret=0;
@@ -380,7 +377,6 @@ long ZCALLBACK win32_seek64_file_func (voidpf opaque, voidpf stream,ZPOS64_T off
         {
             DWORD dwErr = GetLastError();
             ((WIN32FILE_IOWIN*)stream) -> error=(int)dwErr;
-            ret = -1;
         }
         else
             ret=0;

--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -1279,10 +1279,10 @@ extern int ZEXPORT unzLocateFile (unzFile file, const char *szFileName, int iCas
     /* We failed, so restore the state of the 'current file' to where we
      * were.
      */
-    s->num_file = num_fileSaved ;
-    s->pos_in_central_dir = pos_in_central_dirSaved ;
-    s->cur_file_info = cur_file_infoSaved;
-    s->cur_file_info_internal = cur_file_info_internalSaved;
+    s->num_file = num_fileSaved ; //-V1048
+    s->pos_in_central_dir = pos_in_central_dirSaved ; //-V1048
+    s->cur_file_info = cur_file_infoSaved; //-V1048
+    s->cur_file_info_internal = cur_file_info_internalSaved; //-V1048
     return err;
 }
 

--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -1135,6 +1135,9 @@ extern int ZEXPORT zipOpenNewFileInZip4_64 (zipFile file, const char* filename, 
 
     zi->ci.central_header = (char*)ALLOC((uInt)zi->ci.size_centralheader + zi->ci.size_centralExtraFree);
 
+    if (zi->ci.central_header == NULL)
+        return ZIP_INTERNALERROR;
+
     zi->ci.size_centralExtra = size_extrafield_global;
     zip64local_putValue_inmemory(zi->ci.central_header,(uLong)CENTRALHEADERMAGIC,4);
     /* version info */
@@ -1176,8 +1179,6 @@ extern int ZEXPORT zipOpenNewFileInZip4_64 (zipFile file, const char* filename, 
     for (i=0;i<size_comment;i++)
         *(zi->ci.central_header+SIZECENTRALHEADER+size_filename+
               size_extrafield_global+i) = *(comment+i);
-    if (zi->ci.central_header == NULL)
-        return ZIP_INTERNALERROR;
 
     zi->ci.zip64 = zip64;
     zi->ci.totalCompressedData = 0;
@@ -1578,7 +1579,7 @@ extern int ZEXPORT zipCloseFileInZipRaw64 (zipFile file, ZPOS64_T uncompressed_s
     if ((zi->ci.method == Z_DEFLATED) && (!zi->ci.raw))
     {
         int tmp_err = deflateEnd(&zi->ci.stream);
-        if (err == ZIP_OK)
+        if (err == ZIP_OK) //-V1051
             err = tmp_err;
         zi->ci.stream_initialised = 0;
     }
@@ -1586,7 +1587,7 @@ extern int ZEXPORT zipCloseFileInZipRaw64 (zipFile file, ZPOS64_T uncompressed_s
     else if((zi->ci.method == Z_BZIP2ED) && (!zi->ci.raw))
     {
       int tmperr = BZ2_bzCompressEnd(&zi->ci.bstream);
-                        if (err==ZIP_OK)
+                        if (err==ZIP_OK) //-V1051
                                 err = tmperr;
                         zi->ci.stream_initialised = 0;
     }
@@ -1972,7 +1973,7 @@ extern int ZEXPORT zipRemoveExtraInfoBlock (char* pData, int* dataLen, short sHe
     else
     {
       // Extra Info block should not be removed, So copy it to the temp buffer.
-      memcpy(pTmp, p, dataSize + 4);
+      memcpy(pTmp, p, dataSize + 4); //-V575
       p += dataSize + 4;
       size += dataSize + 4;
     }
@@ -1986,7 +1987,7 @@ extern int ZEXPORT zipRemoveExtraInfoBlock (char* pData, int* dataLen, short sHe
 
     // copy the new extra info block over the old
     if(size > 0)
-      memcpy(pData, pNewHeader, size);
+      memcpy(pData, pNewHeader, size); //-V575
 
     // set the new extra info size
     *dataLen = size;

--- a/deflate.c
+++ b/deflate.c
@@ -629,7 +629,7 @@ int ZEXPORT deflateParams(strm, level, strategy)
         int err = deflate(strm, Z_BLOCK);
         if (err == Z_STREAM_ERROR)
             return err;
-        if (strm->avail_in || (s->strstart - s->block_start) + s->lookahead)
+        if (strm->avail_in || (uInt)(s->strstart - s->block_start + s->lookahead))
             return Z_BUF_ERROR;
     }
     if (s->level != level) {

--- a/infback.c
+++ b/infback.c
@@ -458,7 +458,6 @@ void FAR *out_desc;
                values here (9 and 6) without reading the comments in inftrees.h
                concerning the ENOUGH constants, which depend on those values */
             state->next = state->codes;
-            state->lencode = (code const FAR *)(state->next);
             state->lenbits = 9;
             ret = inflate_table(LENS, state->lens, state->nlen, &(state->next),
                                 &(state->lenbits), state->work);
@@ -518,7 +517,6 @@ void FAR *out_desc;
                 ROOM();
                 *put++ = (unsigned char)(state->length);
                 left--;
-                state->mode = LEN;
                 break;
             }
 

--- a/uncompr.c
+++ b/uncompr.c
@@ -60,11 +60,11 @@ int ZEXPORT uncompress2(dest, destLen, source, sourceLen)
 
     do {
         if (stream.avail_out == 0) {
-            stream.avail_out = left > (uLong)max ? max : (uInt)left;
+            stream.avail_out = left > (uLong)max ? max : (uInt)left; //-V547
             left -= stream.avail_out;
         }
         if (stream.avail_in == 0) {
-            stream.avail_in = len > (uLong)max ? max : (uInt)len;
+            stream.avail_in = len > (uLong)max ? max : (uInt)len; //-V547
             len -= stream.avail_in;
         }
         err = inflate(&stream, Z_NO_FLUSH);
@@ -79,7 +79,7 @@ int ZEXPORT uncompress2(dest, destLen, source, sourceLen)
     inflateEnd(&stream);
     return err == Z_STREAM_END ? Z_OK :
            err == Z_NEED_DICT ? Z_DATA_ERROR  :
-           err == Z_BUF_ERROR && left + stream.avail_out ? Z_DATA_ERROR :
+           err == Z_BUF_ERROR && (left + stream.avail_out) > 0 ? Z_DATA_ERROR :
            err;
 }
 


### PR DESCRIPTION
Lvl	ErrorCode CWE		Message											Project	Short file	Line
2	V547	CWE-570		Expression 'sourceLen > (uLong) max' is always false.		ZLib	compress.c	56
2	V547	CWE-570		Expression 'left > (uLong) max' is always false.			ZLib	compress.c	52
2	V1048	CWE-1164	Variable was assigned the same value.						ZLib	ioapi.c		83
2	V1048	CWE-1164	The 'ret' variable was assigned the same value.				ZLib	iowin32.c	292
2	V1048	CWE-1164	The 'ret' variable was assigned the same value.				ZLib	iowin32.c	318
2	V1048	CWE-1164	The 'ret' variable was assigned the same value.				ZLib	iowin32.c	400
2	V1048	CWE-1164	The 'ret' variable was assigned the same value.				ZLib	iowin32.c	359
2	V1048	CWE-1164	The 's->pos_in_central_dir' variable
						was assigned the same value.								ZLib	unzip.c		1284
2	V1048	CWE-1164	The 's->num_file' variable was assigned the same value.		ZLib	unzip.c		1283
2	V1051	CWE-754		Consider checking for misprints.
						It's possible that the 'tmp_err' should be checked here.	ZLib	zip.c		1586
2	V575	CWE-628		The potential null pointer is passed into 'memcpy' function.
						Inspect the first argument. Check lines: 1980, 1965.		ZLib	zip.c		1980
2	V575	CWE-628		The potential null pointer is passed into 'memcpy' function.
						Inspect the second argument. Check lines: 1994, 1965.		ZLib	zip.c		1994
2	V769	CWE-119		The 'zi->ci.central_header' pointer in the 'zi->ci.central_header + 4' expression could be nullptr. In such case, resulting value will be senseless and it should not be used.
						Check lines: 1141, 1136.									ZLib	zip.c		1141
2	V793	CWE-691		It is odd that the result of the '+' operator is a part of the condition.
						Perhaps, this statement should have been compared with something else.	ZLib	deflate.c	636
2	V1048	CWE-1164	The 'state->lencode' variable was assigned the same value.	ZLib	infback.c	463
2	V1048	CWE-1164	The 'state->mode' variable was assigned the same value.		ZLib	infback.c	522
2	V547	CWE-570		Expression 'left > (uLong) max' is always false.			ZLib	uncompr.c	64
2	V547	CWE-570		Expression 'len > (uLong) max' is always false.				ZLib	uncompr.c	68
2	V793	CWE-691		It is odd that the result of the 'left + stream.avail_out' statement is a part of the condition.
						Perhaps, this statement should have been compared with something else.	ZLib	uncompr.c	83
